### PR TITLE
Fixed Flaky tests due to JSON assertion

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -166,8 +167,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
+    ObjectMapper objectMapper = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test


### PR DESCRIPTION
### Setup
Java: 11.0.20
Apache Maven: 3.6.3

### Fixes
Fixed Flaky tests due to JSON assertion:
  - `org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten`

#### Description
The test ` org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten` may fail due to flakiness. The flakiness occurs because  is due to failing assertion when comparing two JSON strings. The test ```testFlat1Flatten``` compares a hard-coded JSON ```FLAT_JSON``` with a data from parquet file ```example/flattening/test_flat_1.parquet```  which is converted to a Hash Map by ```CreateReader``` function. However, the function ```CreateReader``` does not return a deterministic string since there is no guarantee of order of returned fields in Hash Map and thus, some tests can fail due to a different order. The flakiness can be identified by running the [Nondex](https://github.com/TestingResearchIllinois/NonDex) tool

### Steps to reproduce
1.  `git clone git clone https://github.com/apache/druid.git`
2.  `mvn install -pl extensions-core/parquet-extensions -am -DskipTests`
3. Run the tests
`mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten`
4. Run the tests with Nondex
`mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten`

The following error is noticed
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.839 s <<< FAILURE! - in org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest
[ERROR] org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest.testFlat1 Flatten - Time elapsed: 0.073 s <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<{
  "ListDim" : [ "listDim1v1", "listDim1v2" ],
  "dim3" : 1,
  "dim2" : "d2v1",
  "dim1" : "d1v1",
  "metric1" : 1,
  "timestamp" : 1537229880023
}> but was:<{
  "dim3" : 1,
  "timestamp" : 1537229880023,
  "dim2" : "d2v1",
  "ListDim" : [ "listDim1v1", "listDim1v2" ],
  "metric1" : 1,
  "dim1" : "d1v1"
}>

at org.junit.Assert.assertEquals(Assert.java:117)

```

### Fix
Used the Jackson library which contains JsonNode and ObjectMapper. These are used to parse two JSON strings and convert them to a tree structure and each node in the trees are compared. Thus, the order of the elements in JSON strings is deterministic and the test passes.

### How Has This Been Tested?

The fix was tested by running the Nondex plugin again and ensuring that all the tests pass in FULL Mode and ONE Mode of the Nondex runs.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
